### PR TITLE
update main.rs to set --max-intron-out to 100000

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -225,7 +225,7 @@ async fn dna2gfe(
             "--trans",
             "--aln",
             "--max-intron-out",
-            "20000",
+            "100000",
             "-G",
             "20000",
             "--outs=0.975",


### PR DESCRIPTION
--max-intron-out updated to 100000 to allow large introns to be printed out in .gff3 file in whole.